### PR TITLE
Fix: Ensure generated tag is correctly passed to asset upload job

### DIFF
--- a/.github/workflows/build-python-release.yml
+++ b/.github/workflows/build-python-release.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       upload_url: ${{ steps.create_gh_release.outputs.upload_url }}
-      release_tag: ${{ steps.create_gh_release.outputs.tag_name }}
+      release_tag: ${{ steps.generate_tag_name.outputs.tag_name }} # Propagate the originally generated tag
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
@@ -24,7 +24,9 @@ jobs:
       - name: Generate Release Tag and Name
         id: generate_tag_name
         run: |
-          RELEASE_TAG="build-${{ github.ref_name }}-${{ github.run_id }}-${{ github.run_attempt }}"
+          SHORT_SHA=$(echo "${{ github.sha }}" | cut -c1-7)
+          RELEASE_DATE=$(date +'%Y%m%d')
+          RELEASE_TAG="release-${RELEASE_DATE}-${SHORT_SHA}"
           RELEASE_NAME="Musicova Multi-Platform Build ${{ github.sha }}"
           RELEASE_BODY=$(cat <<EOF
             Automated multi-platform build of Musicova (PyQt5 version) executable from commit `${{ github.sha }}`.


### PR DESCRIPTION
Changed the `create-release` job to output the `tag_name` from the `generate_tag_name` step directly, instead of the `tag_name` output by the `create_gh_release` step.

This is to ensure the exact generated tag string is used by the `build-executables` job when uploading assets, potentially resolving an issue where the tag was not found by one of the build matrix jobs (macOS).